### PR TITLE
Add optional 'key' arg to makeDispatchMapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ export default class Todos extends Component {
 }
 ```
 
+#### Separating mapped actions in your properties
+
+If your app contains a large number of actions, you may wish to have them all mapped to an object under a specific key in your properties. Just pass a second argument with the desired key name to makeDispatchMapper, e.g:
+
+```js
+const mapDispatchToProps = makeDispatchMapper({
+	addTodo
+}, 'actions');  // Put them all in component's this.props.actions
+
+/**
+ * This will give props like:
+ * {
+ *   actions: {
+ *     addTodo: function() {...}
+ *   }
+ * }
+ */
+```
+
 ## License
 
 MIT © [Fahad Ibnay Heylaal](http://fahad19.com)

--- a/src/makeDispatchMapper.js
+++ b/src/makeDispatchMapper.js
@@ -1,4 +1,4 @@
-module.exports = function (actionCreators) {
+module.exports = function (actionCreators, key) {
   return function (dispatch) {
     const props = {};
 
@@ -8,6 +8,13 @@ module.exports = function (actionCreators) {
       props[propName] = function (...args) { // eslint-disable-line
         return dispatch(actionCreator(...args));
       };
+    }
+
+    // If the optional 'key' argument was given, return an object which nests the props under that key.
+    if (typeof key == 'string' || typeof key == 'number') {
+      var nested_props = {};
+      nested_props[key] = props;
+      return nested_props;
     }
 
     return props;

--- a/test/makeDispatchMapper.js
+++ b/test/makeDispatchMapper.js
@@ -8,7 +8,7 @@ describe('makeDispatchMapper', function () {
     expect(makeDispatchMapper).to.be.a('function');
   });
 
-  it('generates props with functions', function () {
+  describe('props generation', function () {
     const dispatch = function (action) {
       return action.type;
     };
@@ -21,15 +21,30 @@ describe('makeDispatchMapper', function () {
       };
     };
 
-    const mapDispatchToProps = makeDispatchMapper({
-      addTodo
+    it('generates props with functions', function () {
+
+      const mapDispatchToProps = makeDispatchMapper({
+        addTodo
+      });
+
+      expect(mapDispatchToProps).to.be.a('function');
+
+      const props = mapDispatchToProps(dispatch);
+      expect(props).to.have.key('addTodo');
+      expect(props.addTodo).to.be.a('function');
+      expect(props.addTodo()).to.be(ADD_TODO);
     });
 
-    expect(mapDispatchToProps).to.be.a('function');
-
-    const props = mapDispatchToProps(dispatch);
-    expect(props).to.have.key('addTodo');
-    expect(props.addTodo).to.be.a('function');
-    expect(props.addTodo()).to.be(ADD_TODO);
+    it('returns nested props if optional "key" arg is provided', function () {
+      const KEY = 'this_is_where_I_want_my_actions';
+      const mapDispatchToProps = makeDispatchMapper({
+        addTodo
+      }, KEY);
+      const props = mapDispatchToProps(dispatch);
+      expect(props).to.have.key(KEY);
+      expect(props[KEY].addTodo).to.be.a('function');
+      expect(props[KEY].addTodo()).to.be(ADD_TODO);
+    });
   });
+
 });


### PR DESCRIPTION
This adds a second, optional, `key` parameter to makeDispatchMapper.

If 'key' is passed, then makeDispatchMapper will return an object with all the actions nested under that key (in another object).

Normally the component receives actions mixed in `this.props` with Redux state props.
e.g.
when making dispatch mapper via `makeDispatchMapper({addTodo})`, the component gets these properties:
`this.props = { addTodo: function() {...}, todos: [...]}`

For larger applications it may be useful to gather all actions into a single key within this.props. If we pass 'actions' for the 'key' argument to makeDispatchMapper, our component will see:
e.g.
when making dispatch mapper via `makeDispatchMapper({addTodo}, "actions")`, the component gets these properties:
`this.props = { actions: {addTodo: function() {...}}, todos: [...]}`
